### PR TITLE
Second/itermut

### DIFF
--- a/src/second.rs
+++ b/src/second.rs
@@ -3,8 +3,9 @@
  * - Converted the Link enum into an Option type
  * - Replaced mem::replace and match with in-built Option methods
  * - Introduced Generic Type
- * - Peek and mutable peek 
+ * - Peek and mutable peek
  * - Convert into iterator using IntoIter, Iter, IterMut
+ * - Introduced lifetime specification
  */
 
 // Converting Link into an Option type instead of an enum,

--- a/src/second.rs
+++ b/src/second.rs
@@ -13,7 +13,8 @@ type NodeBox<T> = Box<Node<T>>;
 /// Type representing valid states of list nodes. 
 type Link<T> = Option<NodeBox<T>>;
 
-/// Struct representing the Linked List that keeps track of the head pointer.
+/// Struct representing the Linked List 
+/// that keeps track of the head pointer.
 pub struct List<T> {
     head: Link<T>,
 }
@@ -24,13 +25,20 @@ struct Node<T> {
     next: Link<T>,
 }
 
-/// Iterator providing access to element value while consuming List
+/// Iterator providing sequential access 
+/// to element values while consuming List
 pub struct IntoIter<T>(List<T>);
 
-/// Iterator providing access to references of 
-/// list nodes in sequence, if available
+/// Iterator providing sequential access to 
+/// references of list nodes, if available
 pub struct Iter<'a, T> {
     next: Option<&'a Node<T>>,
+}
+
+/// Iterator providing sequential access to 
+/// mutable references of list nodes in sequence, if available
+pub struct IterMut<'a, T> {
+    next: Option<&'a mut Node<T>>,
 }
 
 impl<T> List<T> {
@@ -44,7 +52,8 @@ impl<T> List<T> {
         let new_node: Box<Node<T>> = Box::new(Node {
             elem: elem,
             next: self.head.take(), 
-            // self.head.take() is same as mem::replace(&mut self.head, None)
+            // self.head.take() is same as 
+            // mem::replace(&mut self.head, None)
         });
 
         self.head = Some(new_node);
@@ -91,7 +100,13 @@ impl<T> List<T> {
     /// Create an Iter struct from List
     pub fn iter(&self) -> Iter<'_, T> {
         Iter { next: self.head.as_deref() }
-        // as_deref() is equivalent to map(|node: &NodeBox<T>| &**node) }
+        // as_deref() is equivalent to 
+        // map(|node: &NodeBox<T>| &**node)
+    }
+
+    /// Create an IterMut struct from List
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+        IterMut { next: self.head.as_deref_mut() }
     }
 
 }
@@ -124,19 +139,33 @@ impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
     
     /// Get next element reference in iterator
-    // Item type handles lifetime requirement, so not required to specify here
     fn next(&mut self) -> Option<Self::Item> {
+        // Item type handles lifetime requirement, 
+        // so not required to specify here
         self.next.map(|node: &Node<T>| {
             self.next = node.next.as_deref();
-            // as_deref() really makes getting references of Box values convenient
+            // as_deref() really makes getting 
+            // references of Box values convenient
             &node.elem
+        })
+    }
+}
+
+impl<'a, T> Iterator for IterMut<'a, T> {
+    type Item = &'a mut T;
+
+    /// Get next mutable element reference in iterator
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next.take().map(|node: &mut Node<T>| {
+            self.next = node.next.as_deref_mut();
+            &mut node.elem
         })
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::{List, IntoIter, Iter};
+    use super::{List, IntoIter, Iter, IterMut};
 
     /// Testing basic list functionalities
     #[test]
@@ -193,6 +222,7 @@ mod test {
         assert_eq!(list.pop(), Some(42));
     }
 
+    /// Testing IntoIter struct functionality
     #[test]
     fn into_iter() {
         let mut list: List<i32> = List::new();
@@ -208,6 +238,7 @@ mod test {
         assert_eq!(iter.next(), None);
     }
 
+    /// Testing Iter struct functionality
     #[test]
     fn iter() {
         let mut list: List<i32> = List::new();
@@ -220,6 +251,22 @@ mod test {
         assert_eq!(iter.next(), Some(&3));
         assert_eq!(iter.next(), Some(&2));
         assert_eq!(iter.next(), Some(&1));
+        assert_eq!(iter.next(), None);
+    }
+
+    /// Testing IterMut struct functionality
+    #[test]
+    fn iter_mut() {
+        let mut list: List<i32> = List::new();
+        
+        list.push(1);
+        list.push(2);
+        list.push(3);
+
+        let mut iter: IterMut<i32> = list.iter_mut();
+        assert_eq!(iter.next(), Some(&mut 3));
+        assert_eq!(iter.next(), Some(&mut 2));
+        assert_eq!(iter.next(), Some(&mut 1));
         assert_eq!(iter.next(), None);
     }
 }


### PR DESCRIPTION
Added IterMut functionality, i.e. Iterator for mutable references, to Second Linked List (LL2).
IterMut, like Iter, does not consume the List, but provides access to mutable references for the node elements.

Since Rust only allows one mutable reference for a value, IterMut requires a slightly different implementation to Iter functionality, mainly by shifting the ownership of the stored reference to local scope using Option's `take()` method.