### PR TITLE
Added LL3 - Persistent Linked List: Initial Commit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,3 @@
 pub mod first;
 pub mod second;
-
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod third;

--- a/src/third.rs
+++ b/src/third.rs
@@ -1,0 +1,87 @@
+/*
+ * A Persistent Singly-Linked Stack
+ * - Shared ownership of elements
+ * (Box cannot handle this, we use reference counters instead)
+ */
+
+use std::rc::Rc;
+
+type NodeRc<T> = Rc<Node<T>>;
+/// Type representing valid states of list nodes.
+type Link<T> = Option<NodeRc<T>>;
+
+/// Struct representing the Linked List
+/// that keeps track of the head pointer.
+pub struct List<T> {
+    head: Link<T>,
+}
+
+/// Struct representing nodes of Linked List
+struct Node<T> {
+    elem: T,
+    next: Link<T>,
+}
+
+impl<T> List<T> {
+
+    /// Create a new List
+    pub fn new() -> Self {
+        List { head: None }
+    }
+
+    /// Returns a List of shared references of 
+    /// the calling List's nodes, with the new 
+    /// element inserted at the head
+    pub fn prepend(&self, elem: T) -> List<T> {
+        List {
+            head: Some(Rc::new(Node {
+                elem: elem,
+                next: self.head.clone(),
+            })),
+        }
+    }
+
+    /// Returns a reference of the element
+    /// stored at the head of the List, 
+    /// else `None` if the List is empty
+    pub fn head(&self) -> Option<&T> {
+        self.head.as_ref().map(|node: &NodeRc<T>| &node.elem)
+    }
+
+    /// Returns a List of shared references 
+    /// to all nodes following the calling List's head
+    pub fn tail(&self) -> List<T> {
+        List {
+            head: self.head.as_ref().and_then(|node: &NodeRc<T>| node.next.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::List;
+
+    #[test]
+    fn basics() {
+        let list = List::new();
+        assert_eq!(list.head(), None);
+
+        let list = list.prepend(1).prepend(2).prepend(3);
+        assert_eq!(list.head(), Some(&3));
+
+        let list = list.tail();
+        assert_eq!(list.head(), Some(&2));
+
+        let list = list.tail();
+        assert_eq!(list.head(), Some(&1));
+
+        let list = list.tail();
+        assert_eq!(list.head(), None);
+
+        // Make sure empty tail works
+        let list = list.tail();
+        assert_eq!(list.head(), None);
+
+    }
+}
+


### PR DESCRIPTION
- Removed template code in lib.rs
- Added initial code for LL3 - Persistent singly linked list with sharable ownership using Rust's Rc pointer